### PR TITLE
Add fallback for version

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,7 +18,7 @@ parts:
       - astral-uv
     override-build: |
       craftctl default
-      git describe --always > $CRAFT_PART_INSTALL/version
+      git describe --always || echo "unknown-$(date -u +%Y%m%d%H%M%S)" > $CRAFT_PART_INSTALL/version
 
 config:
   options:


### PR DESCRIPTION
git describe --always fails when charmcraft is building from a subrepository, as you can see here[1]. By adding a fallback we should be able to get around this issue while still having the proper version present

[1]: https://github.com/canonical/microovn-operator/actions/runs/16029606022/job/45226452894?pr=19