### PR TITLE
OPEN-4651 Add relation support for multiple microovn apps

### DIFF
--- a/lib/charms/microcluster_token_distributor/v0/token_distributor.py
+++ b/lib/charms/microcluster_token_distributor/v0/token_distributor.py
@@ -24,7 +24,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 logger = logging.getLogger(__name__)
@@ -111,7 +111,7 @@ class TokenDistributorProvides(ops.framework.Object):
             self._handle_mirror(event.relation)
 
     def _on_leader_elected(self, _: ops.RelationChangedEvent):
-        if relation := self.charm.model.get_relation(self.relation_name):
+        for relation in self.charm.model.relations[self.relation_name]:
             if self.charm.unit.is_leader():
                 relation.data[self.charm.unit]["mirror"] = "up"
                 self._handle_mirror(relation)

--- a/tests/unit/test_provides_lib.py
+++ b/tests/unit/test_provides_lib.py
@@ -234,3 +234,18 @@ def test_on_token_relation_changed(leader):
             token_distributor_handle_mirror.assert_called_once()
         else:
             token_distributor_handle_mirror.assert_not_called()
+
+
+def test_on_leader_elected_multiple_related_apps():
+    # Two microcluster apps related on the same endpoint (e.g. multi-arch
+    # microovn) must not raise TooManyRelatedAppsError; every relation is set up.
+    ctx = testing.Context(charm.TokenDistributor)
+    relation_a = testing.Relation(charm.CONTROL_RELATION, "worker-cluster")
+    relation_b = testing.Relation(charm.CONTROL_RELATION, "worker-cluster")
+    with ctx(
+        ctx.on.leader_elected(),
+        testing.State(relations=[relation_a, relation_b], leader=True),
+    ) as manager:
+        manager.run()
+        for relation in manager.charm.model.relations[charm.CONTROL_RELATION]:
+            assert relation.data[manager.charm.unit]["mirror"] == "up"


### PR DESCRIPTION
The microcluster-token-distributor charm fails with TooManyRelatedAppsError when multiple microovn apps relate to microcluster-cluster. Add support for multiple relations

# Description

The microcluster-token-distributor charm assumes exactly one remote application
is related on its `microcluster-cluster` endpoint. When two (or more) microcluster
consumer apps are related to a single token-distributor — e.g. `microovn` (amd64)
and `microovn-arm64` (arm64/DPU) — the charm's `leader-elected` hook crashes with
`TooManyRelatedAppsError`, so it never distributes join tokens. This blocks
multi-architecture (mixed amd64 + arm64 DPU) deployments where separate microovn
applications per architecture are required.

Fixes # ([issue](https://warthogs.atlassian.net/browse/OPEN-4651))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

- Built the charm locally and applied it to maas cluster. Microovn and microcluster recovered from error
- unit test added

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.

[OPEN-4651](https://warthogs.atlassian.net/browse/OPEN-4651)



[OPEN-4651]: https://warthogs.atlassian.net/browse/OPEN-4651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ