### PR TITLE
Bridge cluster tokens across relations for shared multi-app clusters

### DIFF
--- a/lib/charms/microcluster_token_distributor/v0/token_distributor.py
+++ b/lib/charms/microcluster_token_distributor/v0/token_distributor.py
@@ -24,7 +24,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -89,22 +89,64 @@ class TokenDistributorProvides(ops.framework.Object):
             self.charm.on[self.relation_name].relation_changed, self._on_token_relation_changed
         )
 
+    def _collect_cross_relation_mirror(self) -> dict[str, str]:
+        """Aggregate mirror data and hostnames across all cluster relations.
+
+        Multiple microcluster applications may relate to the same distributor
+        on separate relations, yet form a single shared cluster.
+        To let the communicator node generate join tokens for every node and
+        let every consumer find its token, hostnames and tokens must be visible
+        on all relations.
+
+        Returns a mapping of mirror key to value, merged across every
+        microcluster-cluster relation. A real (non-empty) token always wins
+        over EMPTY_STRING so a placeholder never clobbers a generated token.
+        """
+        merged: dict[str, str] = {}
+
+        def _record(key: str, value: str) -> None:
+            if not key.startswith(MIRROR_PREFIX):
+                return
+            existing = merged.get(key)
+            # Prefer a real token over an empty placeholder.
+            if existing is None or (existing == EMPTY_STRING and value != EMPTY_STRING):
+                merged[key] = value
+
+        for rel in self.charm.model.relations[self.relation_name]:
+            rel_data = rel.data
+            # Tokens already mirrored on this distributor unit's databag.
+            for k, v in rel_data[self.charm.unit].items():
+                _record(k, v)
+            for unit in rel.units:
+                unit_data = rel_data[unit]
+                # Tokens exposed by consumer units acting as communicators.
+                if unit_data.get("mirror") == "up":
+                    for k, v in unit_data.items():
+                        _record(k, v)
+                # Register every advertised hostname (as a placeholder if we
+                # do not yet have a token for it).
+                hostname = unit_data.get("hostname")
+                if hostname:
+                    merged.setdefault(mirror_id(hostname), EMPTY_STRING)
+
+        return merged
+
     def _handle_mirror(self, relation):
         relation_data = relation.data
         relation_data[self.charm.unit]["mirror"] = "up"
-        for unit in relation.units:
-            if relation_data[unit].get("mirror") == "up":
-                # add all tokens in the other side of the mirror to this side
-                for k, v in relation_data[unit].items():
-                    if MIRROR_PREFIX in k:
-                        relation_data[self.charm.unit][k] = v
 
-            if "hostname" not in relation_data[unit]:
+        merged = self._collect_cross_relation_mirror()
+        local_data = relation_data[self.charm.unit]
+        for key, value in merged.items():
+            current = local_data.get(key)
+            if current == value:
                 continue
-            mirror_key = mirror_id(relation_data[unit]["hostname"])
-            if mirror_key not in relation_data[self.charm.unit]:
-                logger.info("added {0} to mirror".format(mirror_key))
-                relation_data[self.charm.unit][mirror_key] = EMPTY_STRING
+            # Never overwrite a real token we already hold with a placeholder.
+            if current is not None and current != EMPTY_STRING and value == EMPTY_STRING:
+                continue
+            if current is None:
+                logger.info("added {0} to mirror".format(key))
+            local_data[key] = value
 
     def _on_token_relation_changed(self, event: ops.RelationChangedEvent):
         if self.charm.unit.is_leader():

--- a/tests/unit/test_provides_lib.py
+++ b/tests/unit/test_provides_lib.py
@@ -249,3 +249,84 @@ def test_on_leader_elected_multiple_related_apps():
         manager.run()
         for relation in manager.charm.model.relations[charm.CONTROL_RELATION]:
             assert relation.data[manager.charm.unit]["mirror"] == "up"
+
+
+def test_hostname_bridged_across_relations():
+    """Hostnames must be bridged across all microcluster-cluster relations."""
+    ctx = testing.Context(charm.TokenDistributor)
+    # Relation A: already clustered, one node advertising its hostname.
+    relation_a = testing.Relation(
+        charm.CONTROL_RELATION,
+        "worker-cluster",
+        remote_units_data={0: {"hostname": "node-0", "mirror": "up"}},
+    )
+    # Relation B: DPU microovn, a fresh node advertising its hostname.
+    relation_b = testing.Relation(
+        charm.CONTROL_RELATION,
+        "worker-cluster",
+        remote_units_data={0: {"hostname": "dpu-0"}},
+    )
+    with ctx(
+        ctx.on.start(),
+        testing.State(relations=[relation_a, relation_b], leader=True),
+    ) as manager:
+        relations = manager.charm.model.relations[charm.CONTROL_RELATION]
+        rel_a = next(r for r in relations if r.id == relation_a.id)
+
+        # Handle relation A (as happens when relation A changes).
+        manager.charm.token_distributor._handle_mirror(rel_a)
+
+        databag_a = rel_a.data[manager.charm.unit]
+
+        # Relation A learns about its own node hostname
+        assert databag_a.get("mirror-node-0") == token_lib.EMPTY_STRING
+        # The hostname from relation B is bridged into relation A,
+        # so the communicator can mint its join token.
+        assert databag_a.get("mirror-dpu-0") == token_lib.EMPTY_STRING
+
+
+def test_token_bridged_across_relations():
+    """A token minted on one relation must be visible on every relation.
+
+    Once the communicator node (on relation A) generates a join token for the
+    relation-B hostname, that token must appear in the mirror the relation-B
+    consumer reads, so the DPU node joins the shared cluster.
+    """
+    ctx = testing.Context(charm.TokenDistributor)
+    # Relation A: the communicator node has already minted a token for the
+    # hostname and exposed it (mirrored) on its unit databag.
+    relation_a = testing.Relation(
+        charm.CONTROL_RELATION,
+        "worker-cluster",
+        remote_units_data={
+            0: {
+                "hostname": "node-0",
+                "mirror": "up",
+                "mirror-dpu-0": "join-token-abc",
+                "mirror-node-0": token_lib.EMPTY_STRING,
+            }
+        },
+    )
+    # Relation B: DPU microovn node advertising its hostname, no token yet.
+    relation_b = testing.Relation(
+        charm.CONTROL_RELATION,
+        "worker-cluster",
+        remote_units_data={0: {"hostname": "dpu-0"}},
+    )
+    with ctx(
+        ctx.on.start(),
+        testing.State(relations=[relation_a, relation_b], leader=True),
+    ) as manager:
+        relations = manager.charm.model.relations[charm.CONTROL_RELATION]
+        rel_a = next(r for r in relations if r.id == relation_a.id)
+        rel_b = next(r for r in relations if r.id == relation_b.id)
+
+        # Handle both relations (order should not matter for the end state).
+        manager.charm.token_distributor._handle_mirror(rel_a)
+        manager.charm.token_distributor._handle_mirror(rel_b)
+
+        databag_b = rel_b.data[manager.charm.unit]
+
+        # The join token minted via relation A is visible on relation B, so the
+        # DPU consumer can find and consume it.
+        assert databag_b.get("mirror-dpu-0") == "join-token-abc"


### PR DESCRIPTION
# Description
The token distributor handled each microcluster-cluster relation in isolation, so two applications relating to the same distributor (e.g. microovn for amd64 and microovn-arm64 for a DPU) never shared join tokens and each bootstrapped its own separate cluster.

Aggregate hostnames and mirror tokens across all microcluster-cluster relations, so the communicator node mints join tokens for every app node and every other app leader joins the shared cluster instead of bootstrapping. A real token always wins over the empty placeholder.

Fixes #2161627

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)